### PR TITLE
Upgrade of gitlab4j-api to version 4.14.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.gitlab4j</groupId>
             <artifactId>gitlab4j-api</artifactId>
-	    <version>4.12.1</version>
+	    <version>4.14.20</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Pleas upgrade version of gitlab4j-api to 4.14.20. Many usefull APIs like ReleasesAPI etc. are available in newer version