### PR TITLE
update gitlab4j and use jersey2 and jackson2 plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,10 +95,13 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jersey2-api</artifactId>
+            <!-- TODO https://github.com/jenkinsci/bom/pull/1011 -->
+            <version>2.35-6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
+            <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.gitlab4j</groupId>
             <artifactId>gitlab4j-api</artifactId>
-            <version>4.20.0-SNAPSHOT</version>
+            <version>5.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.glassfish.jersey.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,41 @@
         <dependency>
             <groupId>org.gitlab4j</groupId>
             <artifactId>gitlab4j-api</artifactId>
-	    <version>4.14.20</version>
+            <version>4.20.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.inject</groupId>
+                    <artifactId>jersey-hk2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.connectors</groupId>
+                    <artifactId>jersey-apache-connector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-multipart</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-json-jackson</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jersey2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.289.x</artifactId>
-                <version>1246.va_b_50630c1d19</version>
+                <version>1280.vd669827e38cd</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -72,7 +72,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jersey2-api</artifactId>
-            <version>2.35-6</version> <!-- TODO https://github.com/jenkinsci/bom/pull/1011 -->
         </dependency>
         <dependency>
             <groupId>org.gitlab4j</groupId>
@@ -125,7 +124,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version> <!-- TODO https://github.com/jenkinsci/bom/pull/1013 -->
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,14 +66,30 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>javax-activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jersey2-api</artifactId>
+            <version>2.35-6</version> <!-- TODO https://github.com/jenkinsci/bom/pull/1011 -->
+        </dependency>
+        <dependency>
             <groupId>org.gitlab4j</groupId>
             <artifactId>gitlab4j-api</artifactId>
             <version>5.0.1</version>
             <exclusions>
+                <!-- Provided by javax-activation-api plugin -->
                 <exclusion>
-                    <groupId>org.glassfish.jersey.inject</groupId>
-                    <artifactId>jersey-hk2</artifactId>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
                 </exclusion>
+                <!-- Provided by core -->
+                <exclusion>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                </exclusion>
+                <!-- Provided by jersey2-api plugin -->
                 <exclusion>
                     <groupId>org.glassfish.jersey.connectors</groupId>
                     <artifactId>jersey-apache-connector</artifactId>
@@ -83,29 +99,33 @@
                     <artifactId>jersey-client</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.glassfish.jersey.media</groupId>
-                    <artifactId>jersey-media-multipart</artifactId>
+                    <groupId>org.glassfish.jersey.inject</groupId>
+                    <artifactId>jersey-hk2</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.glassfish.jersey.media</groupId>
                     <artifactId>jersey-media-json-jackson</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-multipart</artifactId>
+                </exclusion>
+                <!-- TODO Unneeded test library https://github.com/gitlab4j/gitlab4j-api/pull/840 -->
+                <exclusion>
+                    <groupId>uk.org.webcompere</groupId>
+                    <artifactId>system-stubs-jupiter</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+        <!-- Needed by jersey-apache-connector, but jersey2-api plugin declares it as optional -->
         <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>jersey2-api</artifactId>
-            <!-- TODO https://github.com/jenkinsci/bom/pull/1011 -->
-            <version>2.35-6</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version> <!-- TODO https://github.com/jenkinsci/bom/pull/1013 -->
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Updated the plugin to use the `jersey2-api` and `jackson2-api` plugins instead of packaging its own version of jersey.

~~This PR requires a modification of `gitlab4j-api` and also `jersey2-api`~~
~~https://github.com/gitlab4j/gitlab4j-api/pull/795~~
~~https://github.com/jenkinsci/jersey2-api-plugin/pull/9~~

fixes #8 

Once this PR is merged and released, we also need to release `gitlab-branch-source-plugin` with the following PR

https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/188


This will fix the following error I had if I installed the `jersey2-api` plugin in jenkins:

```
org.glassfish.jersey.internal.inject.InjectionManagerFactory
java.lang.ClassCastException: Cannot cast org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory to org.glassfish.jersey.internal.inject.InjectionManagerFactory
	at java.base/java.lang.Class.cast(Class.java:3605)
	at org.glassfish.jersey.internal.ServiceFinder$LazyObjectIterator.hasNext(ServiceFinder.java:690)
	at org.glassfish.jersey.internal.inject.Injections.lookupService(Injections.java:88)
	at org.glassfish.jersey.internal.inject.Injections.lookupInjectionManagerFactory(Injections.java:73)
	at org.glassfish.jersey.internal.inject.Injections.createInjectionManager(Injections.java:44)
	at org.glassfish.jersey.client.ClientConfig$State.initRuntime(ClientConfig.java:412)
	at org.glassfish.jersey.internal.util.collection.Values$LazyValueImpl.get(Values.java:317)
	at org.glassfish.jersey.client.ClientConfig.getRuntime(ClientConfig.java:807)
	at org.glassfish.jersey.client.ClientRequest.getClientRuntime(ClientRequest.java:219)
	at org.glassfish.jersey.client.ClientRequest.getInjectionManager(ClientRequest.java:610)
	at org.glassfish.jersey.client.JerseyWebTarget.onBuilder(JerseyWebTarget.java:364)
	at org.glassfish.jersey.client.JerseyWebTarget.request(JerseyWebTarget.java:192)
	at org.glassfish.jersey.client.JerseyWebTarget.request(JerseyWebTarget.java:36)
	at org.gitlab4j.api.GitLabApiClient.invocation(GitLabApiClient.java:783)
	at org.gitlab4j.api.GitLabApiClient.invocation(GitLabApiClient.java:748)
	at org.gitlab4j.api.GitLabApiClient.get(GitLabApiClient.java:399)
	at org.gitlab4j.api.GitLabApiClient.get(GitLabApiClient.java:387)
	at org.gitlab4j.api.AbstractApi.get(AbstractApi.java:213)
Caused: org.gitlab4j.api.GitLabApiException: Cannot cast org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory to org.glassfish.jersey.internal.inject.InjectionManagerFactory
	at org.gitlab4j.api.AbstractApi.handle(AbstractApi.java:655)
	at org.gitlab4j.api.AbstractApi.get(AbstractApi.java:215)
	at org.gitlab4j.api.RepositoryApi.getBranch(RepositoryApi.java:104)
	at io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource.retrieve(GitLabSCMSource.java:258)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:582)
	at io.jenkins.plugins.gitlabbranchsource.helpers.GitLabPipelineStatusNotifier$JobScheduledListener.lambda$onEnterWaiting$0(GitLabPipelineStatusNotifier.java:392)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
