### PR TITLE
Migrating gitlab4j-api to 6.0.0-rc.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
 
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>gitlab-api</artifactId>
-    <version>${revision}-${changelist}</version>
+    <version>${revision}</version>
     <packaging>hpi</packaging>
 
     <properties>
-        <revision>5.2.0</revision>
-        <changelist>999999-SNAPSHOT</changelist>
+        <revision>6.0.0-rc.1</revision>
+        <changelist>SNAPSHOT</changelist>
         <jenkins.version>2.361.4</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
@@ -130,7 +130,7 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/ui/repos/tree/General/snapshots/</url>
         </repository>
     </repositories>
     <pluginRepositories>


### PR DESCRIPTION
For the GitLab Plugin Modernization Project under GSoC, we want to use the GitLab4J-API unreleased version 6.0.0-rc.1 due to some added features. As upstream has not responded for its release yet, Kris deployed this to Jenkins Artifactory [here](https://repo.jenkins-ci.org/ui/repos/tree/General/snapshots/gitlab4j/gitlab4j-api/6.x/gitlab4j-api-6.0.0-rc.1.jar). 
The draft PR will allow us to consume the snapshot in GitLab Plugin

### Testing Done

I tests ran successfully when I ran `mvn clean install`. This is the stack trace which I got : 
```
[INFO] Scanning for projects...
[WARNING] The POM for org.jenkins-ci.tools:maven-hpi-plugin:jar:3.43 is missing, no dependency information available
[WARNING] Failed to build parent project for io.jenkins.plugins:gitlab-api:hpi:6.0.0-rc.1
[INFO] 
[INFO] -------------------< io.jenkins.plugins:gitlab-api >--------------------
[INFO] Building GitLab API Plugin 6.0.0-rc.1
[INFO]   from pom.xml
[INFO] --------------------------------[ hpi ]---------------------------------
[INFO] 
[INFO] --- clean:3.2.0:clean (default-clean) @ gitlab-api ---
[INFO] Deleting /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target
[INFO] 
[INFO] --- hpi:3.43:validate (default-validate) @ gitlab-api ---
[INFO] 
[INFO] --- hpi:3.43:validate-hpi (default-validate-hpi) @ gitlab-api ---
[INFO] 
[INFO] --- enforcer:3.3.0:enforce (display-info) @ gitlab-api ---
[INFO] Rule 0: io.jenkins.tools.incrementals.enforcer.RequireExtensionVersion passed
[INFO] Rule 1: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO] Rule 2: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO] Rule 3: org.apache.maven.plugins.enforcer.EnforceBytecodeVersion passed
[INFO] Rule 4: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
[INFO] Rule 5: org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps passed
[INFO] 
[INFO] --- enforcer:3.3.0:enforce (no-snapshots-in-release) @ gitlab-api ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.dependency.RequireReleaseDeps passed
[INFO] 
[INFO] --- localizer:1.31:generate (default) @ gitlab-api ---
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ gitlab-api ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] 
[INFO] --- flatten:1.4.1:flatten (flatten) @ gitlab-api ---
[INFO] Generating flattened POM of project io.jenkins.plugins:gitlab-api:hpi:6.0.0-rc.1...
[INFO] 
[INFO] --- compiler:3.11.0:compile (default-compile) @ gitlab-api ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- access-modifier-checker:1.31:enforce (default-enforce) @ gitlab-api ---
[INFO] 
[INFO] --- hpi:3.43:insert-test (default-insert-test) @ gitlab-api ---
[INFO] 
[INFO] --- antrun:3.1.0:run (createTempDir) @ gitlab-api ---
[INFO] Executing tasks
[INFO]     [mkdir] Created dir: /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/tmp
[INFO] Executed tasks
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ gitlab-api ---
[INFO] skip non existing resourceDirectory /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/src/test/resources
[INFO] 
[INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ gitlab-api ---
[INFO] Changes detected - recompiling the module! :source
[INFO] Compiling 1 source file with javac [debug release 11] to target/test-classes
[INFO] 
[INFO] --- hpi:3.43:test-hpl (default-test-hpl) @ gitlab-api ---
[INFO] Generating /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/test-classes/the.hpl
[INFO] 
[INFO] --- hpi:3.43:resolve-test-dependencies (default-resolve-test-dependencies) @ gitlab-api ---
[INFO] 
[INFO] --- hpi:3.43:test-runtime (default-test-runtime) @ gitlab-api ---
[INFO] Setting jenkins.addOpens to --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED
[INFO] Setting jenkins.insaneHook to --patch-module='java.base=/Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/patch-modules/org-netbeans-insane-hook.jar' --add-exports=java.base/org.netbeans.insane.hook=ALL-UNNAMED
[INFO] 
[INFO] --- surefire:3.0.0:test (default-test) @ gitlab-api ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
Running tests for io.jenkins.plugins:gitlab-api:6.0.0-rc.1
[INFO] Running InjectedTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.039 s - in InjectedTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- license:1.15:process (default) @ gitlab-api ---
[INFO] Generated /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api/WEB-INF/licenses.xml
[INFO] 
[INFO] --- hpi:3.43:hpi (default-hpi) @ gitlab-api ---
[INFO] Generating /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api/META-INF/MANIFEST.MF
[INFO] Checking for attached .jar artifact ...
[INFO] Generating jar /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api.jar
[INFO] Building jar: /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api.jar
[INFO] Exploding webapp...
[INFO] Copy webapp webResources to /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api
[INFO] Assembling webapp gitlab-api in /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api
[INFO] Bundling direct dependency gitlab4j-api-6.0.0-rc.1.jar
[INFO] Generating hpi /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api.hpi
[INFO] Building jar: /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api.hpi
[INFO] 
[INFO] --- jar:3.3.0:test-jar (maybe-test-jar) @ gitlab-api ---
[INFO] Skipping packaging of the test-jar
[INFO] 
[INFO] >>> spotbugs:4.7.3.4:check (spotbugs) > :spotbugs @ gitlab-api >>>
[INFO] 
[INFO] --- spotbugs:4.7.3.4:spotbugs (spotbugs) @ gitlab-api ---
[INFO] 
[INFO] <<< spotbugs:4.7.3.4:check (spotbugs) < :spotbugs @ gitlab-api <<<
[INFO] 
[INFO] 
[INFO] --- spotbugs:4.7.3.4:check (spotbugs) @ gitlab-api ---
[INFO] 
[INFO] --- spotless:2.36.0:check (default) @ gitlab-api ---
[INFO] Spotless check skipped
[INFO] 
[INFO] --- install:3.1.1:install (default-install) @ gitlab-api ---
[INFO] Installing /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api-6.0.0-rc.1.pom to /Users/harshpratapsingh/.m2/repository/io/jenkins/plugins/gitlab-api/6.0.0-rc.1/gitlab-api-6.0.0-rc.1.pom
[INFO] Installing /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api.hpi to /Users/harshpratapsingh/.m2/repository/io/jenkins/plugins/gitlab-api/6.0.0-rc.1/gitlab-api-6.0.0-rc.1.hpi
[INFO] Installing /Users/harshpratapsingh/Desktop/Jenkins/gitlab-api-plugin/target/gitlab-api.jar to /Users/harshpratapsingh/.m2/repository/io/jenkins/plugins/gitlab-api/6.0.0-rc.1/gitlab-api-6.0.0-rc.1.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20.572 s
[INFO] Finished at: 2023-06-11T23:02:03+05:30
[INFO] ------------------------------------------------------------------------
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
