### PR TITLE
Bump gitlab4j-api from 5.2.0 to 5.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <revision>5.2.0</revision>
+        <revision>5.3.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.361.4</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>


### PR DESCRIPTION
I would like to use this new version in order to solve

https://github.com/jenkinsci/gitlab-branch-source-plugin/issues/323
