### PR TITLE
[JENKINS-76091] Use gitlab4j 5.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <revision>5.6.0</revision>
+        <revision>5.8.1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.baseline>2.492</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.bundledArtifacts>gitlab4j-api</hpi.bundledArtifacts>
         <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3893.v213a_42768d35</version>
+                <version>5422.v0fce72a_b_b_8cf</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## [JENKINS-76091](https://issues.jenkins.io/browse/JENKINS-76091) Use gitlab4j 5.8.1 to fix SNAKE_CASE missing symbol

https://github.com/jenkinsci/gitlab-api-plugin/pull/121#issuecomment-3315647668

To work with Jackson 2.20 without migrating to Jersey 3

### Testing done

mvn clean install

Verified failure in GitLab branch source without this change and confirmed that the failure does not happen when this change is used.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
